### PR TITLE
Update DocumentGenerator.php

### DIFF
--- a/vendor/doctrine-mongodb-odm/lib/Doctrine/ODM/MongoDB/Tools/DocumentGenerator.php
+++ b/vendor/doctrine-mongodb-odm/lib/Doctrine/ODM/MongoDB/Tools/DocumentGenerator.php
@@ -168,7 +168,14 @@ public function <methodName>()
      */
     public function writeDocumentClass(ClassMetadataInfo $metadata, $outputDirectory)
     {
-        $path = $outputDirectory . '/' . str_replace('\\', DIRECTORY_SEPARATOR, $metadata->name) . $this->extension;
+        
+        if (strcmp(substr($metadata->name, 0, 4),'App\\') === 0) {
+            $str = substr($metadata->name,4, strlen($metadata->name));
+            $path = $outputDirectory . '/' . str_replace('\\', DIRECTORY_SEPARATOR, $str) . $this->extension;
+        }else{
+            $path = $outputDirectory . '/' . str_replace('\\', DIRECTORY_SEPARATOR, $metadata->name) . $this->extension;
+        }
+        
         $dir = dirname($path);
 
         if ( ! is_dir($dir)) {


### PR DESCRIPTION
when I use the "doctrine:mongodb:generate:documents" command, getters/setters are generated in src/App/Document instead src/Document folder, I dont know if this patch is the right way but it's works for me.